### PR TITLE
Add pytest suite and fix markdown output path

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,15 @@ python parse_strategy.py sample/EURUSD_M5.json -v
 3. **View** the generated markdown with structured strategy information
 4. **Implement** in AlgoWizard using the translated instructions
 
+## ✅ Running Tests
+
+Tests are written using `pytest` and located in the `tests/` directory. To run
+them:
+
+```bash
+python -m pytest
+```
+
 ## 🤝 Contributing
 
 Contributions are welcome! Please feel free to submit pull requests.

--- a/parse_collection.py
+++ b/parse_collection.py
@@ -379,8 +379,10 @@ def to_markdown(strategy_dict, output_path):
     lines.append(f"5. Configure take profit at {strategy_dict['take_profit']} pips")
     lines.append(f"6. Set position size to {strategy_dict['position_size']} lots")
     
-    # Create directory if it doesn't exist
-    os.makedirs(os.path.dirname(output_path), exist_ok=True)
+    # Create directory if one is specified
+    output_dir = os.path.dirname(output_path)
+    if output_dir:
+        os.makedirs(output_dir, exist_ok=True)
     
     try:
         with open(output_path, 'w', encoding='utf-8') as out_file:

--- a/parse_strategy.py
+++ b/parse_strategy.py
@@ -263,8 +263,10 @@ def to_markdown(strategy_dict, output_path):
         for param in optimization.get("Parameters", []):
             lines.append(f"   - {param.get('Name', 'Unknown')}: range {param.get('Min', 'N/A')} to {param.get('Max', 'N/A')}")
 
-    # Create directory if it doesn't exist
-    os.makedirs(os.path.dirname(output_path), exist_ok=True)
+    # Create directory if one is specified
+    output_dir = os.path.dirname(output_path)
+    if output_dir:
+        os.makedirs(output_dir, exist_ok=True)
     
     try:
         with open(output_path, 'w', encoding='utf-8') as out_file:

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -1,0 +1,31 @@
+import os
+from pathlib import Path
+
+import parse_strategy
+import parse_collection
+
+
+def test_parse_eas_strategy_sample():
+    res = parse_strategy.parse_eas_strategy('sample/EURUSD_M5.json')
+    assert res['symbol'] == 'EURUSD'
+    assert res['timeframe'] == 'M5'
+    assert len(res['entry_conditions']) == 3
+    assert res['entry_conditions'][0]['indicator'] == 'RSI'
+    assert res['exit_conditions'][0]['indicator'] == 'Trailing Stop'
+
+
+def test_parse_eas_collection_sample():
+    res = parse_collection.parse_eas_collection('Strategy Collection 1 EURUSD M30.json')
+    assert res['symbol'] == 'EURUSD'
+    assert res['timeframe'] == 'M30'
+    assert len(res['entry_conditions']) == 2
+    assert res['entry_conditions'][0]['indicator'] == 'Directional Indicators'
+    assert res['exit_conditions'][0]['indicator'] == 'Pin Bar'
+
+
+def test_to_markdown_no_directory(tmp_path, monkeypatch):
+    res = parse_strategy.parse_eas_strategy('sample/EURUSD_M5.json')
+    monkeypatch.chdir(tmp_path)
+    output_file = 'output.md'
+    parse_strategy.to_markdown(res, output_file)
+    assert (tmp_path / output_file).exists()


### PR DESCRIPTION
## Summary
- allow `to_markdown` to work when output path has no directory
- add basic pytest suite for strategy and collection parsing
- document how to run the tests

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*