### PR TITLE
Fix pathless output handling

### DIFF
--- a/parse_collection.py
+++ b/parse_collection.py
@@ -379,8 +379,10 @@ def to_markdown(strategy_dict, output_path):
     lines.append(f"5. Configure take profit at {strategy_dict['take_profit']} pips")
     lines.append(f"6. Set position size to {strategy_dict['position_size']} lots")
     
-    # Create directory if it doesn't exist
-    os.makedirs(os.path.dirname(output_path), exist_ok=True)
+    # Create directory if it doesn't exist and a directory was specified
+    output_dir = os.path.dirname(output_path)
+    if output_dir:
+        os.makedirs(output_dir, exist_ok=True)
     
     try:
         with open(output_path, 'w', encoding='utf-8') as out_file:

--- a/parse_strategy.py
+++ b/parse_strategy.py
@@ -263,8 +263,10 @@ def to_markdown(strategy_dict, output_path):
         for param in optimization.get("Parameters", []):
             lines.append(f"   - {param.get('Name', 'Unknown')}: range {param.get('Min', 'N/A')} to {param.get('Max', 'N/A')}")
 
-    # Create directory if it doesn't exist
-    os.makedirs(os.path.dirname(output_path), exist_ok=True)
+    # Create directory if it doesn't exist and a directory was specified
+    output_dir = os.path.dirname(output_path)
+    if output_dir:
+        os.makedirs(output_dir, exist_ok=True)
     
     try:
         with open(output_path, 'w', encoding='utf-8') as out_file:

--- a/tests/test_markdown_output.py
+++ b/tests/test_markdown_output.py
@@ -1,0 +1,54 @@
+import os
+import tempfile
+import unittest
+import parse_strategy
+import parse_collection
+
+
+class MarkdownOutputTest(unittest.TestCase):
+    def minimal_strategy_dict(self):
+        return {
+            "symbol": "EURUSD",
+            "timeframe": "M5",
+            "entry_conditions": [],
+            "exit_conditions": [],
+            "stop_loss": 0,
+            "take_profit": 0,
+            "position_size": 1,
+            "direction": "Long",
+            "optimization": {},
+            "backtest": {},
+        }
+
+    def minimal_collection_dict(self):
+        return {
+            "symbol": "EURUSD",
+            "timeframe": "M30",
+            "entry_conditions": [],
+            "exit_conditions": [],
+            "stop_loss": 0,
+            "take_profit": 0,
+            "position_size": 1,
+            "direction": "Long",
+            "magic_number": 123,
+            "opposite_entry_signal": False,
+            "is_trailing_stop": False,
+            "backtest_stats": {},
+        }
+
+    def test_markdown_no_directory(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            current = os.getcwd()
+            try:
+                os.chdir(tmpdir)
+                parse_strategy.to_markdown(self.minimal_strategy_dict(), "strategy.md")
+                self.assertTrue(os.path.exists("strategy.md"))
+
+                parse_collection.to_markdown(self.minimal_collection_dict(), "collection.md")
+                self.assertTrue(os.path.exists("collection.md"))
+            finally:
+                os.chdir(current)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- avoid creating directories when output filename has no directory
- do the same in collection parser
- test writing markdown to the current directory

## Testing
- `python -m unittest discover -s tests -p 'test*.py' -v`
